### PR TITLE
Creation of a SamlFormAuthenticate (standalone) to authenticate both in Auth and SAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,31 @@ Check the following logs for possible information:
 * Apache error log
 * PHP error log (if different from the Apache error log)
 * simpleSAMLphp log
+
+Use SamlForm to authenticate using both SimpleSamlPHP and Auth->FormAuthenticate
+---------------
+First, load the custom authenticate method:
+
+	public $components = array(
+		'Auth' => array(
+	               'authenticate' => array('Saml.SamlForm'))
+	);
+	
+Then use it as you would normally use any FormAuthenticate. For example:
+- a login page could have both a form to login manually and a link to login via SimpleSamlPHP. The controller would then have something like this:
+
+	if($this->Auth->login())
+	{
+		$this->redirect($this->Auth->redirectUrl());
+	}
+	// Generate the samlLoginLink and after authenticate redirect to the same page
+		$samlLoginLink = $this->Saml->getLoginURL(Router::url($this->here, true));
+		$this->set(compact('samlLoginLink'));
+
+To logout of BOTH the session and SimpleSamlPHP, it is as simple as this:
+
+	$this->Auth->logout();
+	
+Note: in SamlFormAuthenticate.php you can add custom operations in authenticate().
+For example, you could unify SAML attributes with users in the database. If the SAML user does not exist -> create it the database using 'uid' as 'username'. If the SAML user already exists -> fetch the info in the database.
+This way, you could have a unified database using both your own users and SAML users.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ First, load the custom authenticate method:
 	);
 	
 Then use it as you would normally use any FormAuthenticate. For example:
-- a login page could have both a form to login manually and a link to login via SimpleSamlPHP. The controller would then have something like this:
+A login page could have both a form to login manually and a link to login via SimpleSamlPHP. The controller would then have something like this:
 
 	if($this->Auth->login())
 	{

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Use SamlForm to authenticate using both SimpleSamlPHP and Auth->FormAuthenticate
 First, load the custom authenticate method:
 
 	public $components = array(
+		'Saml.Saml',
 		'Auth' => array(
 	               'authenticate' => array('Saml.SamlForm'))
 	);

--- a/Saml/Controller/Component/Auth/SamlFormAuthenticate.php
+++ b/Saml/Controller/Component/Auth/SamlFormAuthenticate.php
@@ -1,0 +1,97 @@
+<?php
+/** This Authenticate component allows a double authentication (SAML and FormAuthenticate)
+  * It uses code from Ben Vidulich to integrate SimpleSamlPHP with CakePHP https://github.com/bvidulich/CakePHP-simpleSAMLphp-Plugin
+  * Customized by Jeff Stich (scith)
+ */
+
+App::uses('FormAuthenticate', 'Controller/Component/Auth');
+
+class SamlFormAuthenticate extends FormAuthenticate {
+
+	private $path = NULL;
+	private $authSource = 'default-sp';
+	private $as;
+
+	/**
+	 * Initializes a SimpleSAML_Auth_Simple object.
+	 *
+	 * @param string $authSource The ID of the authentication source to use. This will
+	 * override the authentication source set in `app/Config/bootstrap.php`.
+	 */
+	public function __construct(ComponentCollection $collection, array $settings, string $authSource = NULL) {
+		// Check the config
+		if (Configure::read('Saml.SimpleSamlPath') != NULL) {
+			$this->path = Configure::read('Saml.SimpleSamlPath');
+		} else {
+			throw new Exception('Parameter Saml.SimpleSamlPath is missing from the configuration file.');
+		}
+		
+		if ($authSource != NULL) {
+			$this->authSource = $authSource;
+		} elseif (Configure::read('Saml.AuthSource') != NULL) {
+			$this->authSource = Configure::read('Saml.AuthSource');
+		}
+		
+		// Initialize simpleSAMLphp
+		require_once($this->path.'/lib/_autoload.php');
+		$this->as = new SimpleSAML_Auth_Simple($this->authSource);
+	}
+
+
+/**
+ * Authenticates the identity contained in a request. Will use the `settings.userModel`, and `settings.fields`
+ * to find POST data that is used to find a matching record in the `settings.userModel`. Will return false if
+ * there is no post data, either username or password is missing, or if the scope conditions have not been met.
+ *
+ * @param CakeRequest $request The request that contains login information.
+ * @param CakeResponse $response Unused response object.
+ * @return mixed False on login failure. An array of User data on success.
+ */
+
+ 	public function authenticate(CakeRequest $request, CakeResponse $response) {
+		$userModel = $this->settings['userModel'];
+		list(, $model) = pluginSplit($userModel);
+
+		// If the user is already authenticated in SimpleSamlPHP
+		if ($this->as->isAuthenticated())
+		{
+			$user = $this->as->getAttributes();
+			// The SAML attributes are sent to the session
+			/** This is where you should add code if you want to unify SAML attributes with users in database.
+			  * Check if it exists in DB with _findUser($username) (using 'uid' as 'username' for example)
+				*	If Yes (_findUser returns true) -> send it to $user
+				*	If No (_findUser returns false) -> add it in the DB (or print "have to create an account first", or anything you want)
+			 */
+		}
+
+		// Else if the user logins via a Form, attributes are retrieved in the database (standard AuthForm) and sent to the session
+		else {
+			$fields = $this->settings['fields'];
+			if (!$this->_checkFields($request, $model, $fields)) {
+				return false;
+			}
+
+			// Try to find the user in the database with the information provided
+			$user = $this->_findUser(
+				$request->data[$model][$fields['username']],
+				$request->data[$model][$fields['password']]
+			);
+		}
+
+		// If wrong information, return false
+		if (!$user) {
+			return false;
+		}
+
+		// Else return the user token
+		return $user;
+	}
+
+	// This function hooks into AuthComponent::logout and extends it to add a SAML logout in addition to the session logout
+	public function logout($user) {
+	    if ($this->as->isAuthenticated()) {
+	        $this->as->logout();
+	    }
+	}
+
+}


### PR DESCRIPTION
Here is my take on a single Auth custom component. This creates a standalone login/logout using both SimpleSamlPHP and FormAuthenticate. Example of usage (and potential improvements) in readme and comments.
What do you think?
